### PR TITLE
Example fixes

### DIFF
--- a/examples/3d/compositePebiGridWithTwoFaults.m
+++ b/examples/3d/compositePebiGridWithTwoFaults.m
@@ -36,4 +36,4 @@ cr = G.cells.centroids(:,2)<-0.5*G.cells.centroids(:,1) + 0.6 ...
 plotGrid(G, ~cr)
 axis equal tight
 view(-83,50)
-light
+camlight

--- a/voronoi3D/createFaultGridPoints3D.m
+++ b/voronoi3D/createFaultGridPoints3D.m
@@ -73,7 +73,7 @@ F.l.cPos =  1;
 
 for i = 1:numel(faultTri)
   dF        = faultTri{i};
-  R         = rho(dF.Points);
+  R         = rho{i}(dF.Points);
 
   CC        = reshape(dF.Points(dF.ConnectivityList',:)',9,[])';
   R         = reshape(R(dF.ConnectivityList',:),3,[])';

--- a/voronoi3D/createWellGridPoints3D.m
+++ b/voronoi3D/createWellGridPoints3D.m
@@ -59,8 +59,8 @@ W.pts = [];
 for i = 1:numel(wellLines)
   l = wellLines{i};
   
-  lineDist = rho((l(1,:) + l(end,:))/2);
-  wellPts = interLinePath(l, rho, lineDist, [0,0]);
+  lineDist = rho{i}((l(1,:) + l(end,:))/2);
+  wellPts = interLinePath(l, rho{i}, lineDist, [0,0]);
   W.wellPos(i+1) = W.wellPos(i) + size(wellPts,1);
   W.pts = [W.pts; wellPts];
 end


### PR DESCRIPTION
Fixes in generation of 3D fault/well points:  Density functions rho are given as cell array. Honour this when they are used.