### PR TITLE
Accelerate pebiGrid

### DIFF
--- a/distmesh/distmesh2d.m
+++ b/distmesh/distmesh2d.m
@@ -126,7 +126,6 @@ end
 
 if count == maxIt
     warning('DistMesh did not converge in maximum number of iterations.')
-    disp([max(sqrt(sum(deltat*Ftot(d<-geps,:).^2,2))/h0),dptol])
 end
 
 % Clean up final mesh

--- a/distmesh/distmesh2d.m
+++ b/distmesh/distmesh2d.m
@@ -95,7 +95,7 @@ while count<maxIt
   L0=hbars*Fscale*sqrt(sum(L.^2)/sum(hbars.^2));     % L0 = Desired lengths
   
   % Density control - remove points that are too close
-  if mod(count,densityctrlfreq)==0 & any(L0>2*L)
+  if mod(count,densityctrlfreq)==0 && any(L0>2*L)
       p(setdiff(reshape(bars(L0>2*L,:),[],1),1:nfix),:)=[];
       N=size(p,1); pold=inf;
       continue;

--- a/examples/2d/statisticalFractures.m
+++ b/examples/2d/statisticalFractures.m
@@ -1,25 +1,38 @@
 %% Create a fractrued reservoir
-% The following fractures are taken from a dataset in the HFM module in MRST
-% Before you run this code you probably want to reduce the maximum number
-% of iterations in distmesh to around 30-40 or this will take a very long
-% time
+% The following fractures are taken from a dataset in the HFM module in
+% MRST. The example full will take at least 8-10 minutes to run, depending
+% on your computer. To lower the runtime, we select a subset of the
+% fractures by restricting the domain along the y-axis. Likewise, we
+% linearize the computation of edge-length distance in distmesh2d.
 
 %{
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % Copyright (C) 2016 Runar Lie Berge. See COPYRIGHT.TXT for details.
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %}  
+mrstModule add upr
 
-%% load dataset
+%% Load dataset and possibly select a subset of the fractures
+% To select a smaller subset of the fractures, you can set yMax to be
+% smaller than the default value of 120.
+yMax = 60;
 pth = fullfile(mrstPath('upr'), 'datasets', 'statistical_fractures.mat');
 load(pth)
-l = mat2cell(fl, ones(size(fl,1),1), size(fl,2));
-l = l';
-offset = 2;
-l = cellfun(@(c) reshape(c', 2,[])' + offset,l,'un',false);
+l = mat2cell(fl, ones(size(fl,1),1), size(fl,2)).';
+l = cellfun(@(c) reshape(c', 2,[])' + 2,l,'un',false);
+
+ix = false(size(l));
+for i=1:numel(ix)
+  ll=l{i}; 
+  ix(i) = max(ll(:,2))<yMax;
+end
+l = l(ix);
 
 clf;
-plotLinePath(l);
+patch([0 35 35 0],[0 0 yMax yMax],ones(4,1),'FaceColor',[.95 .95 1])
+plotLinePath(l,'LineWidth',1);
+axis equal
+
 %% Set grid parameters.
 % We need to refine the grid in some areas since some fractures are very
 % close to each other, but not intersecting.
@@ -29,17 +42,18 @@ refPts = [17.4,79.5; 15.0,71.6; 25.9,98.7; 25.8,97.9; ...
           9.1,87.0;  13.0,87.6; 13.1,88.5; 9.0 ,66.2; ...
           28.95,77;  26.0,70.0; 20.8,69.2; 24.9,24.8; 26.8,38.9];
 amp = [0.5,0.7,0.3,0.3,0.4,0.4,0.4,.6,.3,.45,.45,.2,.3,0.25,0.55,0.45,0.6];
+ix = false(size(eps));
+for i=1:numel(ix) 
+  ix(i) = refPts(i,2)<yMax;
+end
+[eps,amp,refPts] = deal(eps(ix),amp(ix),refPts(ix,:));
 faultRho =@(p) min(ones(size(p,1),1), ...
-                   min(bsxfun(@times, amp,exp(bsxfun(@rdivide, pdist2(p,refPts),eps))),[],2));
+    min(bsxfun(@times, amp,exp(bsxfun(@rdivide, distance(p,refPts),eps))),[],2));
+
 %% Generate grid
-% Note that this may take some time to execute
-G = pebiGrid(15,[35,120],'faultLines',l,'faultGridFactor',1/50,...
+G = pebiGrid(15,[35,yMax],'faultLines',l,'faultGridFactor',1/50,...
              'circleFactor',0.62,'faultRefinement',true,'faultEps',5,...
-             'faultRho', faultRho);
-           
+             'faultRho', faultRho,'useMrstPebi',true,'linearize', true);
 
 %% plot grid
-figure(); hold on
-plotGrid(G)
-plotLinePath(l,'--');
-axis equal
+plotGrid(G,'FaceColor','none')

--- a/util/minPdist2.m
+++ b/util/minPdist2.m
@@ -1,0 +1,14 @@
+function d=minPdist2(X, Y)
+% Calculate the distance from one point set to the nearest point in another
+%
+% SYNOPSIS
+%     d = minPdist2(x, x)
+% Arguments:
+%    x        n x d array holding n points
+%    y        n x d array holding m points
+% Returns:
+%    d        d(i) is the distance from x(i,:) to the nearest point y
+%
+% Written by Knut-Andreas Lie
+d = sqrt(min(abs(bsxfun(@plus, sum(X.^2,2),sum(Y.^2,2)') - 2*(X*Y')),[],2));
+end

--- a/util/pdist2.m
+++ b/util/pdist2.m
@@ -6,12 +6,10 @@ function d = pdist2(x,y)
   % Returns:
   %    d        Matrix where d(i,j) is the distance from
   %             x(i,:) to y(j,:)
-  % Written by Halvor Møll Nilsen
-      d=nan(size(x,1),size(y,1));
-    for i=1:size(y,1)
-        dl=sqrt(sum(bsxfun(@minus,x,y(i,:)).^2,2));
-        d(:,i)=dl;
-    end
+  % Uses the fact that 
+  %    ||x-y||^2 = ||x||^2 + ||y||^2 - 2*x.y
+  % and takes the absolute value to avoid problems with roundoff.
+   d = sqrt(abs(bsxfun(@plus, sum(x.^2,2),sum(y.^2,2)') - 2*(x*y')));
 end
 
  

--- a/voronoi2D/createFaultGridPoints.m
+++ b/voronoi2D/createFaultGridPoints.m
@@ -261,7 +261,7 @@ function [Pts, gridSpacing, circCenter, circRadius, f2c,f2cPos, c2f,c2fPos] = ..
     % Test if faultLine is to short
     if numOfFracPts == 1
       d = sqrt(sum((circCenter(2,:)-circCenter(1,:)).^2, 2));
-      if d < 0.8*fh((circCenter(2,:)+circCenter(1,:))/2);
+      if d < 0.8*fh((circCenter(2,:)+circCenter(1,:))/2)
         Pts         = [];
         gridSpacing = [];
         circCenter  = [];

--- a/voronoi2D/pebiGrid.m
+++ b/voronoi2D/pebiGrid.m
@@ -222,7 +222,7 @@ sePtn = (1.0+faultOffset/wellGridSize)*sePtn;
 % create distance functions
 if wellRef && ~isempty(wellPts)
     hresw   = @(x) min((ones(size(x,1),1)/wellGridFactor), ...
-                  1.2*exp(min(pdist2(x,wellPts),[],2)/wellEps));
+                  1.2*exp(minPdist2(x,wellPts)/wellEps));
     hfault = @(x) wellGridSize*faultGridFactor*hresw(x).*faultRho(x);
 else
   hresw   = @(p) constFunc(p)/wellGridFactor;
@@ -235,7 +235,7 @@ F = createFaultGridPoints(faultLines, faultGridSize,'circleFactor', circleFactor
 
 if faultRef && ~isempty(F.f.pts)
   hresf = @(x) min((ones(size(x,1),1)/faultGridFactor), ...
-                    1.2*exp(min(pdist2(x,F.f.pts),[],2)/faultEps));
+                    1.2*exp(minPdist2(x,F.f.pts)/faultEps));
 else
   hresf = @(p) constFunc(p)/wellGridFactor;
 end

--- a/voronoi2D/pebiGrid.m
+++ b/voronoi2D/pebiGrid.m
@@ -95,15 +95,22 @@ function [G,Pts,F] = pebiGrid(resGridSize, pdims, varargin)
 %                     Note that if k>=3 the innput pdims will have no
 %                     effect.
 %   sufFaultCond     - OPTIONAL 
-%                    Default value true. If sufFaultCond = false we don
-%                    not enforce the sufficient and necessary fault
-%                    condition. Instead we enforce a less strict 
-%                    condition and remove any reservoir sites that are 
-%                    closer to the fault sites than the fault grid size.
-%                    Note that Conformity is then not guaranteed. You
-%                    might still set this to false if you have problems
-%                    with bad cells at the end of your faults because the
-%                    sufficient condition removes some reservoir points. 
+%                    Default value true. If sufFaultCond = false we do not
+%                    enforce the sufficient and necessary fault condition.
+%                    Instead we enforce a less strict condition and remove
+%                    any reservoir sites that are closer to the fault sites
+%                    than the fault grid size. Note that Conformity is then
+%                    not guaranteed. You might still set this to false if
+%                    you have problems with bad cells at the end of your
+%                    faults because the sufficient condition removes some
+%                    reservoir points.
+%   linearize        - OPTIONAL
+%                    Default is false. If true, we evaluate the scaled
+%                    edge-length function in distmesh2d by interpolating
+%                    between values computed at the vertices. There are
+%                    usually more edges than vertices and if the
+%                    edge-length function is expensive to compute, this
+%                    will save significant computational time.
 %
 % RETURNS:
 %   G              - Valid grid definition.  
@@ -147,7 +154,8 @@ opt = struct('wellLines',       {{}}, ...
              'protLayer',       false, ...
              'protD',           {{@(p) ones(size(p,1),1)*resGridSize/10}},...
 			 'polyBdr',         zeros(0,2), ...
-			 'sufFaultCond',    true,...
+			 'sufFaultCond',    true,...,
+             'linearize',       false,...,
              'useMrstPebi',     false);
 
 opt             = merge_options(opt, varargin{:});
@@ -277,7 +285,7 @@ else
     hres = @(p, varargin) hresw(p);
 end
 fixedPts = [F.f.pts; wellPts; protPts; F.t.pts; corners];  
-[Pts,~,sorting] = distmesh2d(fd, hres, ds, rectangle, fixedPts,vararg);
+[Pts,~,sorting] = distmesh2d(fd, hres, ds, rectangle, fixedPts, opt.linearize, vararg);
 
 % Distmesh change the order of all points. We undo this sorting.
 isFault = false(max(sorting),1); isFault(1:size(F.f.pts,1)) = true;

--- a/voronoi2D/pebiGrid.m
+++ b/voronoi2D/pebiGrid.m
@@ -222,7 +222,7 @@ sePtn = (1.0+faultOffset/wellGridSize)*sePtn;
 % create distance functions
 if wellRef && ~isempty(wellPts)
     hresw   = @(x) min((ones(size(x,1),1)/wellGridFactor), ...
-                  min(1.2*exp(pdist2(x,wellPts)/wellEps),[],2));
+                  1.2*exp(min(pdist2(x,wellPts),[],2)/wellEps));
     hfault = @(x) wellGridSize*faultGridFactor*hresw(x).*faultRho(x);
 else
   hresw   = @(p) constFunc(p)/wellGridFactor;
@@ -235,7 +235,7 @@ F = createFaultGridPoints(faultLines, faultGridSize,'circleFactor', circleFactor
 
 if faultRef && ~isempty(F.f.pts)
   hresf = @(x) min((ones(size(x,1),1)/faultGridFactor), ...
-                    min(1.2*exp(pdist2(x,F.f.pts)/faultEps),[],2));
+                    1.2*exp(min(pdist2(x,F.f.pts),[],2)/faultEps));
 else
   hresf = @(p) constFunc(p)/wellGridFactor;
 end

--- a/voronoi3D/faultSites.m
+++ b/voronoi3D/faultSites.m
@@ -109,7 +109,7 @@ for f = 1:numel(faults)
 	vararg    = [f_xy; f_xy(1,:)];
     h = @(p, varargin) ds * ones(size(p, 1), 1);
     fixedPts = [internal_pts; tip_sites; corners];  
-    [pts, ~, sorting] = distmesh2d(fd, h, ds, rectangle, fixedPts, vararg);
+    [pts, ~, sorting] = distmesh2d(fd, h, ds, rectangle, fixedPts, false, vararg);
     % Distmesh change the order of all points. We undo this sorting.
     isInt = false(max(sorting),1); isInt(1:size(internal_pts,1)) = true;
     isInt = isInt(sorting);


### PR DESCRIPTION
I have made various changes to accelerate the pebiGrid routine:
1. Make sure that minimum over pdist2 is the innermost operation before any scalings, exponentionals, etc
2. Added new implementation of pdist2 and a new function minPdist2
3. New option 'linearize' to distmesh2d, by which we can compute edge-length distance at vertices and interpolate to edge midpoints. This will be significantly faster if there are many more edges than vertices and the this distance computation is expensive.
4. Updated the statistical fractures example, that motivated these changes.